### PR TITLE
Fix classname log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.gem
 /.bundle/
 /vendor/
+/.idea/

--- a/lib/idy/extension.rb
+++ b/lib/idy/extension.rb
@@ -74,7 +74,7 @@ module Idy
       end
 
       def not_found!(hash)
-        raise ActiveRecord::RecordNotFound, "Couldn't find User with 'idy'=#{hash.inspect}"
+        raise ActiveRecord::RecordNotFound, "Couldn't find #{self.name} with 'idy'=#{hash.inspect}"
       end
     end
   end

--- a/spec/lib/idy/extension/findy_bump_spec.rb
+++ b/spec/lib/idy/extension/findy_bump_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Article, '#findy!' do
       let!(:hash) { 'My' }
 
       it 'raises' do
-        message = %(Couldn't find User with 'idy'="My")
+        message = %(Couldn't find Article with 'idy'="My")
 
         expect { described_class.findy!(hash) }.to raise_error ActiveRecord::RecordNotFound, message
       end


### PR DESCRIPTION
show correct classname when class raises `ActiveRecord::RecordNotFound` exception